### PR TITLE
Fix build-system in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ isort = "^5.3.2"
 
 [tool.poetry.scripts]
 punk = "which_beer.main:app"
+
+[build-system]
 build-backend = "poetry.masonry.api"
 
 [tool.black]


### PR DESCRIPTION
When I try to run the command `make install` I receive the following error:

```python
Installing the current project: which_beer (0.1.0)
  ValueError

  not enough values to unpack (expected 2, got 1)

  at .venv/lib/python3.8/site-packages/poetry/masonry/builders/editable.py:141 in _add_scripts
      137│ 
      138│         scripts = entry_points.get("console_scripts", [])
      139│         for script in scripts:
      140│             name, script = script.split(" = ")
    → 141│             module, callable_ = script.split(":")
      142│             callable_holder = callable_.rsplit(".", 1)[0]
      143│ 
      144│             script_file = scripts_path.joinpath(name)
      145│             self._debug(
make: *** [Makefile:15: install] Error 1
```

This occurs because in `pyproject.toml` the red line is in the wrong section:

```toml
[tool.poetry.scripts]
punk = "which_beer.main:app"
*build-backend = "poetry.masonry.api"
```

Looking the Poetry Documentation I found [this point](https://python-poetry.org/docs/faq/#is-tox-supported). 

Is this correct? 